### PR TITLE
2 unhandled rejections

### DIFF
--- a/lib/AMQPChannelManager.js
+++ b/lib/AMQPChannelManager.js
@@ -1,4 +1,4 @@
-var EventEmitter = require('events').EventEmitter;
+var EventEmitter = require('./AsyncEventEmitter');
 var when = require('when');
 
 /**
@@ -22,11 +22,11 @@ function AMQPChannelManager(connection, options) {
 	if (typeof(this._options.confirm) === 'undefined') {
 		this._options.confirm = false;
 	}
-	
+
 	this._log = function log(occurence) {
 		console.log('[%s] AMQPChannelManager:', (new Date()).toISOString(), occurence);
 	};
-	
+
 	// If our underlying connection aborts, we need to destroy the channel (i.e. cease our re-creation attempts).
 	connection.once('close', (function() {
 		this._destroyChannel();
@@ -42,16 +42,16 @@ AMQPChannelManager.prototype = Object.create(EventEmitter.prototype);
 AMQPChannelManager.prototype._createChannel = function _createChannel() {
 	var self = this;
 	var connection = self._connection;
-	
-	
+
+
 	// If we're not started, or we already are in the middle of creating a channel, prevent the operation from taking place:
 	if (!self._started || self._creatingChannel) {
 		return;
 	}
-	
+
 	self._creatingChannel = true;
 	var createChannel;
-	
+
 	if (this._options.confirm) {
 		createChannel = connection.createConfirmChannel.bind(connection);
 	}
@@ -72,24 +72,24 @@ AMQPChannelManager.prototype._createChannel = function _createChannel() {
 		 * @param {external:AMQPChannel} channel An object representing the channel. Can be passed to other components requiring an open channel (e.g. {@link module:AMQPBase.AMQPConsumer|AMQPConsumer}).
 		 * @see {@link http://www.squaremobius.net/amqp.node/doc/channel_api.html} for documentation regarding the Channel API.
 		 */
-		self.emit('create', channel);
-		
+		self.emitAsync('create', channel);
+
 		function handleChannelEvent(closeType, eventData) {
 			if (channelDropped) {
 				return;
 			}
-			
+
 			self._channel = null;
 			channelDropped = true;
-			
+
 			/**
 			 * The previously-opened channel has been closed due to an error or a deliberate request using {@link module:AMQPBase.AMQPChannelManager#stop|stop()}.
 			 * @event module:AMQPBase.AMQPChannelManager#close
 			 * @param {external:AMQPChannel} channel The channel which has been closed and is no longer suitable for communicating with the broker.
 			 */
-			self.emit('close', channel);
-			
-			
+			self.emitAsync('close', channel);
+
+
 			// Try re-creating the channel unless somebody told us not to do it:
 			if (!channelDestroyed) {
 				//TODO: Come up with an actual retry strategy:
@@ -98,10 +98,10 @@ AMQPChannelManager.prototype._createChannel = function _createChannel() {
 				}, 3000);
 			}
 		}
-		
+
 		var handleError = handleChannelEvent.bind(undefined, 'error');
 		var handleClose = handleChannelEvent.bind(undefined, 'close');
-		
+
 		channel.on('error', handleError);
 		channel.on('close', handleClose);
 	}, function channelCreationFailed(error) {

--- a/lib/AMQPConnector.js
+++ b/lib/AMQPConnector.js
@@ -1,4 +1,4 @@
-var EventEmitter = require('events').EventEmitter;
+var EventEmitter = require('./AsyncEventEmitter');
 var amqplib = require('amqplib');
 var when = require('when');
 
@@ -17,13 +17,13 @@ var when = require('when');
  */
 function AMQPConnector(serverURI, options) {
 	EventEmitter.call(this);
-	
+
 	// Initial settings:
 	this._serverURIs = (Array.isArray(serverURI)) ? serverURI.slice() : [ serverURI ];
 	options = options || {};
 	options.socket = options.socket || {};
 	this._options = options;
-	
+
 	// State-keeping:
 	this._state = {
 		started: false,
@@ -33,7 +33,7 @@ function AMQPConnector(serverURI, options) {
 		reconnectTimeout: null,
 		destroy: null
 	};
-	
+
 	this._log = function log(occurence) {
 		console.log('[%s] AMQPConnector:', (new Date()).toISOString(), occurence);
 	};
@@ -59,12 +59,12 @@ AMQPConnector.prototype._selectServerURI = function _selectServerURI(lastUsedURI
 AMQPConnector.prototype._createConnection = function _createConnection() {
 	var self = this;
 	var state = this._state;
-	
+
 	// Guard clause: if we are not started (yet/anymore), or already trying to connect, do nothing. This should end a reconnection chain and prevent multiple concurrent connections.
 	if (!state.started || state.connecting) {
 		return;
 	}
-	
+
 	var URI = self._selectServerURI(state.lastUsedURI);
 	state.lastUsedURI = URI;
 	state.connecting = true;
@@ -84,27 +84,27 @@ AMQPConnector.prototype._createConnection = function _createConnection() {
 		 * @event module:AMQPBase.AMQPConnector#connect
 		 * @param {external:AMQPConnection} connection An AMQP connection, suitable for passing into other components which require a connection object (e.g. {@link module:AMQPBase.AMQPChannelManager|AMQPChannelManager}).
 		 */
-		self.emit('connect', connection);
-		
+		self.emitAsync('connect', connection);
+
 		function handleConnectionEvent(closeType, eventData) {
 			// Guard clause: do not react to the connection closing more than one time:
 			if (connectionDropped) {
 				return;
 			}
-			
+
 			state.connection = null;
 			connectionDropped = true;
 			self._log({ event: closeType, eventData: eventData });
 			self._log('connection dropped (' + closeType + '); attempting to reconnect');
-			
+
 			/**
 			 * A connection has been closed, either because of network conditions or manually using {@link module:AMQPBase.AMQPConnector#stop|stop()}.
 			 * @event module:AMQPBase.AMQPConnector#disconnect
 			 * @param {external:AMQPConnection} connection The connection which has been closed and is no longer suitable for use.
 			 * @see {@link http://www.squaremobius.net/amqp.node/doc/channel_api.html} for documentation regarding the Connection API.
 			 */
-			self.emit('disconnect', connection);
-			
+			self.emitAsync('disconnect', connection);
+
 			// Now, try and reconnect, unless we told ourselves not to:
 			if (!connectionDestroyed) {
 				state.reconnectTimeout = setTimeout(function() {
@@ -112,10 +112,10 @@ AMQPConnector.prototype._createConnection = function _createConnection() {
 				}, 1000);
 			}
 		}
-		
+
 		var handleError = handleConnectionEvent.bind(undefined, 'error');
 		var handleClose = handleConnectionEvent.bind(undefined, 'close');
-		
+
 		connection.on('error', handleError);
 		connection.on('close', handleClose);
 	}, function connectionFailed(error) {

--- a/lib/AMQPConsumer.js
+++ b/lib/AMQPConsumer.js
@@ -152,22 +152,26 @@ AMQPConsumer.prototype.consume = function consume() {
 AMQPConsumer.prototype.stopConsuming = function stopConsuming() {
 	var self = this;
 	var currentConsumerTag = self._consumerTag;
-	
+
 	// If the consumer has not even been started, has been stopped, or is currently stopping, there is nothing to do:
 	if (!self._started || self._stopPromise) {
 		return self._stopPromise || when.resolve();
 	}
-	
+
 	self._started = false;
-	
+
 	// We must be certain that the client really is consuming (i.e. has a consumer tag) before trying to cancel the consumer:
 	self._stopPromise = self._consumePromise.then(function cancelCurrentConsumer() {
 		return self._channel.cancel(currentConsumerTag);
+	}).catch(function _ignoreCancellationErrors() {
+		// no-op: we need to eat errors because the channel may very well be closed
+		// After all, the caller wants us not to consume - a closed channel
+		//  indirectly causes this outcome.
 	}).then(function() {
 		self._stopPromise = null;
 	});
 	self._consumePromise = null;
-	
+
 	return self._stopPromise;
 };
 

--- a/lib/AMQPConsumer.js
+++ b/lib/AMQPConsumer.js
@@ -1,4 +1,4 @@
-var EventEmitter = require('events').EventEmitter;
+var EventEmitter = require('./AsyncEventEmitter');
 var when = require('when');
 
 /**
@@ -28,22 +28,22 @@ var when = require('when');
  * @constructor
  * @memberof module:AMQPBase
  * @extends EventEmitter
- * 
+ *
  * @param {external:AMQPChannel} channel The channel which the consumer shall use. The channel must be open - attempts to use a channel that is closed will result in failure.
  * @param {string} queueName Name of the queue that this consumer shall consume from.
  * @param {Object} [options] Settings controlling the behaviour of the consumer. All but the most trivial consumers will want to use this.
- * 
+ *
  * @param {Object} [options.queue] Queue options, controlling the properties of the queue when declaring it on the broker.
  * @param {boolean} [options.queue.durable=true] Whether the queue should be declared as durable (true) or transient (false).
  * @param {boolean} [options.queue.exclusive=false] Whether this queue is exclusive to the channel.
  * @param {boolean} [options.queue.autoDelete=false] Whether the queue should be deleted when the channel is closed.
- * 
+ *
  * @param {Object} [options.consume] Consumption options, which can alter the behaviour of the consumption process itself.
  * @param {boolean} [options.consume.exclusive=false] Whether the consumption process should acquire an exclusive lock on the queue, preventing other consumers from using it at the same time.
  * @param {boolean} [options.consume.prefetch=0] A limit of how many unacked (outstanding) messages the consumer may hold at any given time. Zero means no limit. Note that, on RabbitMQ before version 3.3.0, it applies per-channel, not per-consumer, so the limit is shared between multiple consumers.
- * 
+ *
  * @param {module:AMQPBase.AMQPConsumer~Exchange[]} [options.exchanges] Definitions of exchanges that should be declared at the broker's side before starting consumption.
- * 
+ *
  * @param {module:AMQPBase.AMQPConsumer~Binding[]} [options.binds] Queue bindings that should be established prior to consuming messages.
  */
 function AMQPConsumer(channel, queueName, options) {
@@ -55,7 +55,7 @@ function AMQPConsumer(channel, queueName, options) {
 	this._consumeOptions = options.consume || {};
 	this._exchanges = options.exchanges || [];
 	this._binds = options.binds || [];
-	
+
 	this._consumerTag = null;
 	this._started = false;
 	this._consumePromise = null;
@@ -75,11 +75,11 @@ AMQPConsumer.prototype.consume = function consume() {
 	var consumeOptions = this._consumeOptions;
 	var exchanges = this._exchanges;
 	var binds = this._binds;
-	var emit = this.emit.bind(this);
+	var emitAsync = this.emitAsync.bind(this);
 	var self = this;
 	// Store the actual queue name, in case the caller did not specify one and the server generates one for us:
 	var actualQueueName;
-	
+
 	if (!self._started) {
 		// First, we need to make sure that our queue exists:
 		self._consumePromise = when.try(channel.assertQueue.bind(channel), queueName, queueOptions).then(function rememberActualQueueName(queueInfo) {
@@ -97,11 +97,11 @@ AMQPConsumer.prototype.consume = function consume() {
 			// This is to ensure that our prefetch() setting, if any, will not have been overridden in the meantime (by, for example, establishConsumer() call entries from other consumers).
 			// Within the channel scope, the basic.qos (prefetch) must take place first, because RPCs are synchronous (non-pipelined) in AMQP 0-9-1.
 			var consumptionPromises = [];
-			
+
 			if (consumeOptions.prefetch) {
 				consumptionPromises.push(channel.prefetch(consumeOptions.prefetch));
 			}
-			
+
 			consumptionPromises.push(channel.consume(actualQueueName, function handleMessage(message) {
 				// If the message is a consumer cancellation notification from RabbitMQ, inform the listeners of it:
 				if (message === null) {
@@ -111,7 +111,7 @@ AMQPConsumer.prototype.consume = function consume() {
 					 * The consumer has been cancelled by the server because the queue has been deleted or has failed over (if mirrored).
 					 * @event module:AMQPBase.AMQPConsumer#cancel
 					 */
-					emit('cancel', { initiator: 'server' });
+					emitAsync('cancel', { initiator: 'server' });
 					return;
 				}
 				var ack = channel.ack.bind(channel, message);
@@ -128,7 +128,7 @@ AMQPConsumer.prototype.consume = function consume() {
 				 * @param {function} operations.requeue Return the message to the queue it was obtained from, so that it may be re-delivered.
 				 * @param {function} operations.reject Reject the message, destroying it or, if a dead-letter-exchange has been configured for the consumer's queue, re-routing it to the dead letter exchange.
 				 */
-				emit('message', message, {
+				emitAsync('message', message, {
 					ack: ack,
 					requeue: requeue,
 					reject: reject
@@ -140,7 +140,7 @@ AMQPConsumer.prototype.consume = function consume() {
 		});
 		self._started = true;
 	}
-	
+
 	return self._consumePromise;
 };
 

--- a/lib/AsyncEventEmitter.js
+++ b/lib/AsyncEventEmitter.js
@@ -1,0 +1,24 @@
+'use strict';
+
+var EventEmitter = require('events').EventEmitter;
+
+function AsyncEventEmitter(options) {
+	EventEmitter.call(this, options);
+}
+AsyncEventEmitter.prototype = Object.create(EventEmitter.prototype);
+
+/**
+ * Emit an event in the next tick. This is the same as .emit(), but separates
+ *  the event emission from the currently-executing function frame.
+ * @param {string} eventName - Name of the event to emit.
+ * @param {...*} arg - Argument for the emitted event. Can pass 0 or more arguments.
+ */
+AsyncEventEmitter.prototype.emitAsync = function emitAsync() {
+	var self = this;
+	var emitArgs = arguments;
+	setImmediate(function() {
+		self.emit.apply(self, emitArgs);
+	});
+};
+
+module.exports = AsyncEventEmitter;


### PR DESCRIPTION
This patchset fixes a set of unhandled rejections and unsafe event emitter calling conventions which would cause AMQPConnector to not reconnect after a channel is forcibly closed from the outside.

It also changes the moment when events are emitted from sync (in-stack with the method calls) to async (via `setImmediate`) as a defensive measure. Even though users of this library should not have been depending on the internal state of any components when the events are emitted, a major version bump is warranted for safety.

Fixes #2